### PR TITLE
Clarified how ties are resolved

### DIFF
--- a/docs/conceptual/array.maxby['t,'u]-function-[fsharp].md
+++ b/docs/conceptual/array.maxby['t,'u]-function-[fsharp].md
@@ -47,7 +47,8 @@ Returns the maximum element.
 
 ## Remarks
 
-This function is named `MaxBy` in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
+This function is named `MaxBy` in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.  
+Ties are resolved by returning the element with the lowest ordinal.  
 
 ## Example
 


### PR DESCRIPTION
It's unclear how maxBy works when there are multiple "greatest" values in an array.  
This PR clarifies that.  
