### PR TITLE
Small fix in incorrect code example on up- and downcasting

### DIFF
--- a/docs/conceptual/casting-and-conversions-[fsharp].md
+++ b/docs/conceptual/casting-and-conversions-[fsharp].md
@@ -106,7 +106,7 @@ let base1 = d1 :> Base1
 with
 
 ```fsharp
-base1 = upcast d1
+let base1 = upcast d1
 ```
 
 In the previous code, the argument type and return types are `Derived1` and `Base1`, respectively.


### PR DESCRIPTION
The `let` keyword was missing in the example.

Also, `**upcast** *expression*` and `**downcast** *expression*` does not render correctly on the Microsoft website of this page (i.e., here: https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/casting-and-conversions-%5Bfsharp%5D) as can be seen in this screenshot, the space is missing:

![image](https://user-images.githubusercontent.com/16015770/38157339-5ff28ee8-3486-11e8-92f1-22037006d642.png)

@cartermp, @KevinRansom or anybody, is this an error with the renderer at Microsoft? Because in Markdown and on Github it looks just fine.