### PR TITLE
Master -> Live (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-# NOTE - FROZEN CONTENT
 
-The content of this repository is frozen.
+# Visual F# Documentation
 
-All conceptual documentation (guides, language reference, compiler and F# Interactive reference) are actively maintained [here](https://github.com/dotnet/docs), with a [live set on docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/fsharp/).
+[![Project Status: Suspended - Initial development has started, but there has not yet been a stable, usable release; work has been stopped for the time being but the author(s) intend on resuming work.](http://www.repostatus.org/badges/latest/suspended.svg)](http://www.repostatus.org/#suspended)
 
-All reference content for FSharp.Core will be migrated over to docs.microsoft.com soon, and regular contributions will be accepted in the same repository as the conceptual content (and any changes to that will be reflected here).
+## FROZEN CONTENT
+
+This content is frozen. It will be migrated to docs.microsoft.com.
+
+Welcome to the open F# documentation! As we transitioned the entire publishing pipeline for this document set to Open Publishing, we are now allowing public contributions to the docs. Built and validated documents are published [on MSDN](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/visual-fsharp).
+
+## Troubleshooting & Questions
+Simply [open an issue](https://github.com/Microsoft/visualfsharpdocs/issues) and we'll get in touch as soon as possible.
+
+## Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/docs/conceptual/list.partition['t]-function-[fsharp].md
+++ b/docs/conceptual/list.partition['t]-function-[fsharp].md
@@ -46,7 +46,7 @@ The input list.
 
 ## Return Value
 
-A list containing the elements for which the predicate evaluated to `false` and a list containing the elements for which the predicate evaluated to `true`.
+A list containing the elements for which the predicate evaluated to `true` and a list containing the elements for which the predicate evaluated to `false`.
 
 ## Remarks
 This function is named `Partition` in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.


### PR DESCRIPTION
* Live -> master (#313)

* Fix broken table (#269)

* Fix code indentation (#267)

* corrected the output (#276)

* Update collections.array - fsharp .md (#271)

fixed signature for copy function

* fix and consolidate list.xyz2/xyz3 doc for input lists with different lengths (#282)

* Fix escape sequence. (#285)

* Add missing space (#284)

* Fix order of arguments in foldBack lambda (#286)

Running the following in F# Interactive will help explain why I believe this change is necessary:
> List.foldBack (fun elem acc -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 4 elem: 3 elem: 2 elem: 1 val it : int = 10
> List.foldBack (fun acc elem -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 0 elem: 4 elem: 7 elem: 9 val it : int = 10

The accumulator is the second argument in foldBack (contrary to fold where it is the first).
Positioning the arguments in reverse in an example is a great way to confuse a reader.

This also helps promote the fact that the state and list arguments to the folding function
are in the same order as their lambda counterparts.

Feel free to disagree :-).

* Fix Operators.atan2 description (#287)

atan2(y, x) is related to atan(y/x), *not* atan(x/y)

* Fixed code formatting (#288)

* Corrected prefix minus to prefix plus (#289)

* Added missing line break

Added missing line break to class definition of Microsoft.FSharp.Reflection.UnionCaseInfo

* Removed Missing CustomOperationAttribute Issue #266

* JoinConditionWord was Accidentally removed despite not being duplicated. Fixing this.

* Fix typo in Array2D.init docs

* Document that Map.pick can throw KeynotFoundException

* Update async.startchild['t]-method-[fsharp].md

Specify timeout behaviour

* Fix List.compareWith case

* Update walkthrough-using-visual-fsharp-to-create,-debug,-and-deploy-an-application.md

* Added treatment of null-values, and fixed incomplete text on IFormattable (#301)

The `string` function casts to `IFormattable` internally. The original text only mentioned integer and floating point values, but in fact, there are many more values in the BCL that implement IFormattable. I improved the text to be more precise.

Furthermore, special treatment of `null` was not mentioned, I've added that. Expanded supported platforms, and fixed a typo.

* Update quotations.patterns-module-[fsharp].md (#302)

Thanks @Columpio

* Clarified how ties are resolved (#304)

* Add except to list modules (#305)

The except function added in https://github.com/fsharp/fslang-design/issues/41 doesn't have a doc here.

* Correcting the Return Value in list.partition['t]-function-[fsharp].md  (#309)

* Fix broken table (#269)

* Fix code indentation (#267)

* corrected the output (#276)

* Update collections.array - fsharp .md (#271)

fixed signature for copy function

* fix and consolidate list.xyz2/xyz3 doc for input lists with different lengths (#282)

* Fix escape sequence. (#285)

* Add missing space (#284)

* Fix order of arguments in foldBack lambda (#286)

Running the following in F# Interactive will help explain why I believe this change is necessary:
> List.foldBack (fun elem acc -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 4 elem: 3 elem: 2 elem: 1 val it : int = 10
> List.foldBack (fun acc elem -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 0 elem: 4 elem: 7 elem: 9 val it : int = 10

The accumulator is the second argument in foldBack (contrary to fold where it is the first).
Positioning the arguments in reverse in an example is a great way to confuse a reader.

This also helps promote the fact that the state and list arguments to the folding function
are in the same order as their lambda counterparts.

Feel free to disagree :-).

* Fix Operators.atan2 description (#287)

atan2(y, x) is related to atan(y/x), *not* atan(x/y)

* Fixed code formatting (#288)

* Corrected prefix minus to prefix plus (#289)

* Added missing line break

Added missing line break to class definition of Microsoft.FSharp.Reflection.UnionCaseInfo

* Removed Missing CustomOperationAttribute Issue #266

* JoinConditionWord was Accidentally removed despite not being duplicated. Fixing this.

* Fix typo in Array2D.init docs

* Document that Map.pick can throw KeynotFoundException

* Update async.startchild['t]-method-[fsharp].md

Specify timeout behaviour

* Update walkthrough-using-visual-fsharp-to-create,-debug,-and-deploy-an-application.md

* Added treatment of null-values, and fixed incomplete text on IFormattable (#301)

The `string` function casts to `IFormattable` internally. The original text only mentioned integer and floating point values, but in fact, there are many more values in the BCL that implement IFormattable. I improved the text to be more precise.

Furthermore, special treatment of `null` was not mentioned, I've added that. Expanded supported platforms, and fixed a typo.

* Update list.partition['t]-function-[fsharp].md

* Fixed formatting of README (#291)