### PR TITLE
Remove unnecessary upcast and add missing helper

### DIFF
--- a/docs/conceptual/snippets/fssequences/snippet180.fs
+++ b/docs/conceptual/snippets/fssequences/snippet180.fs
@@ -1,7 +1,11 @@
+    let printSeq seq1 = 
+      for v in seq1 do printf "%A " v
+      printfn ""
 
-    let seqNumbers = [ 1.0; 1.5; 2.0; 1.5; 1.0; 1.5 ] :> seq<float>
+    let seqNumbers = [ 1.0; 1.5; 2.0; 1.5; 1.0; 1.5 ]
     let seqWindows = Seq.windowed 3 seqNumbers
     let seqMovingAverage = Seq.map Array.average seqWindows
+
     printfn "Initial sequence: "
     printSeq seqNumbers
     printfn "\nWindows of length 3: "


### PR DESCRIPTION
The upcast is unnecessary and confusing.

When trying to remove it, I also noticed that `printSeq` was not defined, so I added that. This is defined in some other snippet on some other documentation page, but I think the snippets should be self-contained, so that people can copy & paste & run them.