### PR TITLE
Code-formatted 'greater than' doesn't need to be escaped

### DIFF
--- a/docs/conceptual/operators.[-hh]-]['t1,'t2,'u]-function-[fsharp].md
+++ b/docs/conceptual/operators.[-hh]-]['t1,'t2,'u]-function-[fsharp].md
@@ -64,7 +64,7 @@ The following example demonstrates the use of the `||>` operator.
 **Output:**
 
 ```
-("abc", "def") ||&gt; append gives "abc.def"
+("abc", "def") ||> append gives "abc.def"
 result2: "ABC.DEF"
 ```
 


### PR DESCRIPTION
See formatted view for confirmation.