### PR TITLE
don't html-encode angle bracket in code example

### DIFF
--- a/docs/conceptual/operators.[-hh]-]['t1,'t2,'u]-function-[fsharp].md
+++ b/docs/conceptual/operators.[-hh]-]['t1,'t2,'u]-function-[fsharp].md
@@ -64,7 +64,7 @@ The following example demonstrates the use of the `||>` operator.
 **Output:**
 
 ```
-("abc", "def") ||&gt; append gives "abc.def"
+("abc", "def") ||> append gives "abc.def"
 result2: "ABC.DEF"
 ```
 


### PR DESCRIPTION
it is shown as written in the markdown source, which is not intended. the markdown backtick syntax will encode the ampersand in the code snippet again, resulting double html-encoded, once manual, once by the markdown interpreter.