### PR TITLE
Guarantee partition predicate evaluation

### DIFF
--- a/docs/conceptual/list.partition['t]-function-[fsharp].md
+++ b/docs/conceptual/list.partition['t]-function-[fsharp].md
@@ -35,7 +35,7 @@ List.partition predicate list
 Type: **'T -&gt;**[bool](https://msdn.microsoft.com/library/89c0cf9c-49ce-4207-a3be-555851a67dd5)
 
 
-The function to test the input elements.
+The function to test the input elements. This predicate is evaluated once for each input element.
 
 
 *list*


### PR DESCRIPTION
One of the [design goals](https://github.com/fsharp/fslang-design/blob/master/FSharp-4.0/ListSeqArrayAdditions.md#regular-functional-operators-producing-two-or-more-output-collections) of the `partition` functions that the predicate is evaluated only once (not twice) per item. This should be documented guarantee so that developers can take advantage of it.

A similar guarantee should be added for `Array.partition`.