### PR TITLE
Corrected wording error

### DIFF
--- a/docs/conceptual/map.find['key,'t]-function-[fsharp].md
+++ b/docs/conceptual/map.find['key,'t]-function-[fsharp].md
@@ -58,7 +58,7 @@ This function is named `Find` in compiled assemblies. If you are accessing the f
 
 ## Example
 
-The following examples shows how to use Map.filter.
+The following examples shows how to use Map.find.
 
 [!code-fsharp[Main](snippets/fsmaps/snippet6.fs)]
 


### PR DESCRIPTION
Docs said 'example shows how to use Map.filter' however it should be Map.find