### PR TITLE
Delete TOC.yml

### DIFF
--- a/docs-fsharp-conceptual/TOC.yml
+++ b/docs-fsharp-conceptual/TOC.yml
@@ -1,2 +1,0 @@
-- name: Index
-  href: index.md


### PR DESCRIPTION
The `docs-fsharp-conceptual/TOC.yml` and `docs-fsharp-conceptual/TOC.md` have same output path `docs-fsharp-conceptual/toc.json`, which can cause build failure in docfx v3 build.

This pull request is to fix above issue and unblock docfx v3 migration.